### PR TITLE
Feature/ue5 migration windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # UnrealZeroMQ
-Unreal Engine 4 plugin for ZeroMQ with bindings from [zmqcpp](https://github.com/zeromq/cppzmq).
+Unreal Engine plugin for ZeroMQ with bindings from [zmqcpp](https://github.com/zeromq/cppzmq).
 
 ## Usage
 1. Copy this repository into the `Plugins` folder of your Unreal project.
@@ -24,7 +24,10 @@ UE_LOG(LogTemp, Log, TEXT("ZeroMQ version: v%d.%d.%d), major, minor, patch);
 
 ```
 
-## Support
+## Support Unreal Engine 5
+* Windows x64
+
+## Support Unreal Engine 4
 * Windows (x64 and x86)
 * Linux
 * MacOS

--- a/Source/ZeroMQ/ZeroMQ.Build.cs
+++ b/Source/ZeroMQ/ZeroMQ.Build.cs
@@ -26,25 +26,23 @@ public class ZeroMQ : ModuleRules
         PublicDefinitions.Add("ZMQ_STATIC");
 
         string staticLibrary = "";
-        switch (Target.Platform)
+        if (Target.Platform == UnrealTargetPlatform.Win64)
         {
-            case UnrealTargetPlatform.Win64:
-                staticLibrary = Path.Combine(ZeroMQRootPath, "Windows", "x64", "libzmq-v141-mt-s-4_3_2.lib");
-                break;
-            case UnrealTargetPlatform.Win32:
-                staticLibrary = Path.Combine(ZeroMQRootPath, "Windows", "x86", "libzmq-v141-mt-s-4_3_2.lib");
-                break;
-            case UnrealTargetPlatform.Linux:
-                staticLibrary = Path.Combine(ZeroMQRootPath, "Linux", "libzmq.so");
-                PublicAdditionalLibraries.Add("stdc++");
-                break;
-            case UnrealTargetPlatform.Mac:
-                staticLibrary = Path.Combine(ZeroMQRootPath, "MacOS", "libzmq.a");
-                break;
-            default:
+            staticLibrary = Path.Combine(ZeroMQRootPath, "Windows", "x64", "libzmq-v141-mt-s-4_3_2.lib");
+        }
+        else if (Target.Platform == UnrealTargetPlatform.Linux)
+        {
+            staticLibrary = Path.Combine(ZeroMQRootPath, "Linux", "libzmq.so");
+            PublicAdditionalLibraries.Add("stdc++");
+        }
+        else if (Target.Platform == UnrealTargetPlatform.Mac)
+        {
+            staticLibrary = Path.Combine(ZeroMQRootPath, "MacOS", "libzmq.a");
+        }
+        else
+        {
                 Console.WriteLine("unsupported target platform: %s", Target.Platform);
                 Debug.Assert(false);
-                break;
         }
 
         bEnableExceptions = true;

--- a/ThirdParty/libzmq_4.3.1/include/zmq.hpp
+++ b/ThirdParty/libzmq_4.3.1/include/zmq.hpp
@@ -1,8 +1,8 @@
 
 #if PLATFORM_WINDOWS && !defined(WINDOWS_PLATFORM_TYPES_GUARD)
-	#include <AllowWindowsPlatformTypes.h>
+	#include <Windows/AllowWindowsPlatformTypes.h>
 	#include "zmq_impl.hpp"
-	#include <HideWindowsPlatformTypes.h>
+	#include <Windows/HideWindowsPlatformTypes.h>
 #else
 	#include "zmq_impl.hpp"
 #endif

--- a/ZeroMQ.uplugin
+++ b/ZeroMQ.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "4.3.2",
+	"VersionName": "5.1.1",
 	"FriendlyName": "ZeroMQ",
 	"Description": "C++ bindings zmqcpp as a Unreal Engine 4 plugin. Usage: #include <zmq.hpp>",
 	"Category": "Other",


### PR DESCRIPTION
Added support for Unreal Engine 5 for Windows x64 OS. Key changes:

- Target platform of Windows 32 bit OS is no longer supported in UE5, so was removed
- Switch statements no longer allowed by the compiler, converted to if statement
- Changed ZeroMQ.uplugin version name to UE 5.1.1